### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/danielgtmn/react-umami/security/code-scanning/1](https://github.com/danielgtmn/react-umami/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves operations like checking out code, installing dependencies, building, and publishing to NPM, the `contents: read` permission is sufficient for most steps, while the `packages: write` permission is required for publishing to NPM.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`publish`) in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
