### PR TITLE
fix: ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Run tests
         run: pnpm test:run
 
-      - name: Check bundle size
-        run: pnpm size
-
   publish:
     name: 'Publish to NPM'
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a minor adjustment to the CI workflow by removing the bundle size check step from the test job in `.github/workflows/publish.yml`. This streamlines the workflow and may help reduce CI execution time.