### PR TITLE
feat: add .npmrc for registry configuration and update package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         run: pnpm test:run
 
-  publish:
+  publish-npm:
     name: 'Publish to NPM'
     runs-on: ubuntu-latest
     needs: test
@@ -71,3 +71,35 @@ jobs:
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-github:
+    name: 'Publish to GitHub Packages'
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://npm.pkg.github.com'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to GitHub Packages
+        run: pnpm publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# NPM Registry Configuration
+# Default registry for all packages
+registry=https://registry.npmjs.org/
+
+# GitHub Packages registry for @danielgtmn scope
+@danielgtmn:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -15,12 +15,28 @@ A lightweight, privacy-focused React component for integrating Umami Analytics i
 - 🔄 Async UTM parameter fetching
 - 🌐 Custom domain support
 - ⚙️ Configurable script attributes
+- ⚛️ **React 18 & 19 Support** - Compatible with both React 18.2+ and React 19
+
+## Requirements
+
+- **React**: 18.2+ or 19.0+
+- **Node.js**: 16.0+
 
 ## Installation
 
-Install using pnpm:
+The package is available on both NPM and GitHub Packages:
 
+### From NPM (recommended)
 ```bash
+pnpm add @danielgtmn/umami-react
+```
+
+### From GitHub Packages
+```bash
+# First, configure npm to use GitHub Packages for @danielgtmn scope
+echo "@danielgtmn:registry=https://npm.pkg.github.com" >> .npmrc
+
+# Then install
 pnpm add @danielgtmn/umami-react
 ```
 
@@ -170,7 +186,9 @@ function MyComponent() {
 
 ## Manual Pageview Tracking
 
-The `useUmami` hook now provides comprehensive pageview tracking capabilities, perfect for scenarios where you need to disable auto-tracking and manually control pageview events with custom UTM parameters.
+The `useUmami` hook provides comprehensive pageview tracking capabilities, perfect for scenarios where you need to disable auto-tracking and manually control pageview events with custom UTM parameters.
+
+> **Note**: This library correctly integrates with Umami's official tracking API. Pageviews are tracked using Umami's standard `umami.track()` method without custom event names.
 
 ### Basic Pageview Tracking
 
@@ -534,6 +552,7 @@ pnpm install
 ```
 
 Please feel free to submit a Pull Request!
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielgtmn/umami-react",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": false,
   "description": "The Umami Analytics Loader is a lightweight script that enables you to easily integrate Umami Analytics into your website. Umami is a simple, open-source website analytics tool that provides valuable insights into your website's traffic without compromising privacy.",
   "main": "./dist/index.js",
@@ -81,8 +81,11 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
This pull request introduces support for publishing the package to both NPM and GitHub Packages, updates documentation to reflect these changes, and adds compatibility with React 19. The workflow configuration and package metadata have been updated accordingly, and installation instructions are now clearer for both registries.

**Publishing workflow and registry configuration:**

* Added a new `publish-github` job to `.github/workflows/publish.yml` for publishing to GitHub Packages, and renamed the original job to `publish-npm` for clarity. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L43-R43) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R74-R105)
* Added a `.npmrc` file to configure the default registry and the GitHub Packages registry for the `@danielgtmn` scope.

**Documentation updates:**

* Updated `README.md` to include React 19 support, new requirements, and detailed installation instructions for both NPM and GitHub Packages.
* Clarified manual pageview tracking documentation to note correct integration with Umami's official tracking API.

**Package metadata updates:**

* Updated `peerDependencies` in `package.json` to support React 19, bumped the version to `1.1.0`, and added a `publishConfig` section to ensure public access. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L84-R88)

**Other improvements:**

* Minor formatting fixes in `README.md`.