### PR TITLE
Ci fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Run tests
         run: pnpm test:run
 
-  publish-npm:
+  publish:
     name: 'Publish to NPM'
     runs-on: ubuntu-latest
     needs: test
@@ -71,35 +71,3 @@ jobs:
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-github:
-    name: 'Publish to GitHub Packages'
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
-
-      - name: Publish to GitHub Packages
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-# NPM Registry Configuration
-# Default registry for all packages
-registry=https://registry.npmjs.org/
-
-# GitHub Packages registry for @danielgtmn scope
-@danielgtmn:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielgtmn/umami-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "description": "The Umami Analytics Loader is a lightweight script that enables you to easily integrate Umami Analytics into your website. Umami is a simple, open-source website analytics tool that provides valuable insights into your website's traffic without compromising privacy.",
   "main": "./dist/index.js",


### PR DESCRIPTION
This pull request streamlines the package publishing workflow by removing support for publishing to GitHub Packages and simplifying configuration files. The main focus is on publishing solely to the public NPM registry, which reduces complexity and potential points of failure in the CI/CD pipeline.

Workflow and configuration changes:

* Removed the `publish-github` job from `.github/workflows/publish.yml`, eliminating the steps and configuration needed to publish to GitHub Packages.
* Renamed the `publish-npm` job to `publish` in `.github/workflows/publish.yml` for clarity and consistency.
* Deleted the `.npmrc` file, removing custom registry configurations for both NPM and GitHub Packages.

Version update:

* Updated the package version in `package.json` from `1.1.0` to `1.1.1` to reflect these workflow and configuration changes.