### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/danielgtmn/react-umami/security/code-scanning/7](https://github.com/danielgtmn/react-umami/security/code-scanning/7)

In general, the fix is to declare an explicit `permissions:` block in the workflow to scope down the `GITHUB_TOKEN` privileges to the minimum required. For typical read‑only CI pipelines (checkout, install, lint, test, build, coverage reporting, and bundle-size checks) the workflow only needs read access to repository contents (and possibly to pull requests, which is implied for PR events). This can be done once at the top level (so it applies to all jobs that don’t override it) with `permissions: contents: read`.

The best minimal fix here is to add a root‑level `permissions:` block just after the `on:` section and before `concurrency:` in `.github/workflows/ci.yml`. This documents that the workflow only needs read access to the repository contents and ensures that even if org/repo defaults change, the jobs still run with restricted permissions. None of the jobs appear to require write access (they only read code, run commands, and call Codecov / size‑limit actions), so `contents: read` is sufficient and does not change existing functionality.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the `on:` block (lines 3–7) and the `concurrency:` block (line 9).
- No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
